### PR TITLE
Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -56,12 +56,7 @@
 			Person list example dependencies
 		-->
 		<dependency>
-			<groupId>edelta.example.migration.personlist</groupId>
-			<artifactId>edelta.example.migration.personlist</artifactId>
-			<version>1.0.0-SNAPSHOT</version>			
-		</dependency>
-		<dependency>
-			<groupId>edelta.example.migration.personlist</groupId>
+			<groupId>io.github.lorenzobettini.edelta.examples</groupId>
 			<artifactId>edelta.example.migration.personlist.migrator</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
@@ -77,4 +72,18 @@
 		<finalName>edelta-migrationservice</finalName>
 	</build>
 
+	<repositories>
+		<repository>
+			<id>sonatype-snapshots</id>
+			<name>Sonatype Snapshots</name>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>

--- a/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
+++ b/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
@@ -49,32 +49,64 @@ public class MigrationControllerTest {
 		properties.setModelfolder(tempDir.toString());
 
 		// Input XML for My.persons
-		inputXml1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n" + "    xmi:version=\"2.0\"\n"
-				+ "    xmlns:xmi=\"http://www.omg.org/XMI\"\n" + "    xmlns:person=\"http://edelta/PersonList/v1\">\n"
-				+ "  <members firstname=\"John\"\n" + "      lastname=\"Doe\"/>\n" + "  <members firstname=\"Jane\"\n"
-				+ "      lastname=\"Doe\"\n" + "      gender=\"FEMALE\"/>\n" + "</person:List>";
+		inputXml1 = """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<person:List
+				    xmi:version="2.0"
+				    xmlns:xmi="http://www.omg.org/XMI"
+				    xmlns:person="http://edelta/PersonList/v1">
+				  <members firstname="John"
+				      lastname="Doe"/>
+				  <members firstname="Jane"
+				      lastname="Doe"
+				      gender="FEMALE"/>
+				</person:List>
+				""";
 
 		// Input XML for My2.persons
-		inputXml2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n" + "    xmi:version=\"2.0\"\n"
-				+ "    xmlns:xmi=\"http://www.omg.org/XMI\"\n" + "    xmlns:person=\"http://edelta/PersonList/v1\">\n"
-				+ "  <members firstname=\"John\"\n" + "      lastname=\"Doe\"/>\n" + "  <members firstname=\"Jane\"\n"
-				+ "      lastname=\"Doe\"\n" + "      gender=\"FEMALE\"/>\n" + "</person:List>";
+		inputXml2 = """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<person:List
+				    xmi:version="2.0"
+				    xmlns:xmi="http://www.omg.org/XMI"
+				    xmlns:person="http://edelta/PersonList/v1">
+				  <members firstname="John"
+				      lastname="Doe"/>
+				  <members firstname="Jane"
+				      lastname="Doe"
+				      gender="FEMALE"/>
+				</person:List>
+				""";
 
 		// Expected output XML for My.persons
-		expectedOutputXml1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n"
-				+ "    xmi:version=\"2.0\"\n" + "    xmlns:xmi=\"http://www.omg.org/XMI\"\n"
-				+ "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-				+ "    xmlns:person=\"http://edelta/PersonList/v4\">\n" + "  <members xsi:type=\"person:Male\"\n"
-				+ "      name=\"John Doe\"/>\n" + "  <members xsi:type=\"person:Female\"\n"
-				+ "      name=\"Jane Doe\"/>\n" + "</person:List>";
+		expectedOutputXml1 = """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<person:List
+				    xmi:version="2.0"
+				    xmlns:xmi="http://www.omg.org/XMI"
+				    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				    xmlns:person="http://edelta/PersonList/v4">
+				  <members xsi:type="person:Male"
+				      name="John Doe"/>
+				  <members xsi:type="person:Female"
+				      name="Jane Doe"/>
+				</person:List>
+				""";
 
 		// Expected output XML for My2.persons
-		expectedOutputXml2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n"
-				+ "    xmi:version=\"2.0\"\n" + "    xmlns:xmi=\"http://www.omg.org/XMI\"\n"
-				+ "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-				+ "    xmlns:person=\"http://edelta/PersonList/v4\">\n" + "  <members xsi:type=\"person:Male\"\n"
-				+ "      name=\"John Doe\"/>\n" + "  <members xsi:type=\"person:Female\"\n"
-				+ "      name=\"Jane Doe\"/>\n" + "</person:List>";
+		expectedOutputXml2 = """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<person:List
+				    xmi:version="2.0"
+				    xmlns:xmi="http://www.omg.org/XMI"
+				    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				    xmlns:person="http://edelta/PersonList/v4">
+				  <members xsi:type="person:Male"
+				      name="John Doe"/>
+				  <members xsi:type="person:Female"
+				      name="Jane Doe"/>
+				</person:List>
+				""";
 	}
 
 	@Test

--- a/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
+++ b/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
@@ -1,0 +1,147 @@
+package it.gssi.edelta.migrationservice.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import it.gssi.edelta.migrationservice.configuration.MigrationConfigProperties;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MigrationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MigrationConfigProperties properties;
+
+	@TempDir
+	Path tempDir;
+
+	private String inputXml1;
+	private String inputXml2;
+	private String expectedOutputXml1;
+	private String expectedOutputXml2;
+
+	@BeforeEach
+	void setUp() {
+		// Setup the model folder for tests
+		properties.setModelfolder(tempDir.toString());
+
+		// Input XML for My.persons
+		inputXml1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n" + "    xmi:version=\"2.0\"\n"
+				+ "    xmlns:xmi=\"http://www.omg.org/XMI\"\n" + "    xmlns:person=\"http://edelta/PersonList/v1\">\n"
+				+ "  <members firstname=\"John\"\n" + "      lastname=\"Doe\"/>\n" + "  <members firstname=\"Jane\"\n"
+				+ "      lastname=\"Doe\"\n" + "      gender=\"FEMALE\"/>\n" + "</person:List>";
+
+		// Input XML for My2.persons
+		inputXml2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n" + "    xmi:version=\"2.0\"\n"
+				+ "    xmlns:xmi=\"http://www.omg.org/XMI\"\n" + "    xmlns:person=\"http://edelta/PersonList/v1\">\n"
+				+ "  <members firstname=\"John\"\n" + "      lastname=\"Doe\"/>\n" + "  <members firstname=\"Jane\"\n"
+				+ "      lastname=\"Doe\"\n" + "      gender=\"FEMALE\"/>\n" + "</person:List>";
+
+		// Expected output XML for My.persons
+		expectedOutputXml1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n"
+				+ "    xmi:version=\"2.0\"\n" + "    xmlns:xmi=\"http://www.omg.org/XMI\"\n"
+				+ "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+				+ "    xmlns:person=\"http://edelta/PersonList/v4\">\n" + "  <members xsi:type=\"person:Male\"\n"
+				+ "      name=\"John Doe\"/>\n" + "  <members xsi:type=\"person:Female\"\n"
+				+ "      name=\"Jane Doe\"/>\n" + "</person:List>";
+
+		// Expected output XML for My2.persons
+		expectedOutputXml2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<person:List\n"
+				+ "    xmi:version=\"2.0\"\n" + "    xmlns:xmi=\"http://www.omg.org/XMI\"\n"
+				+ "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+				+ "    xmlns:person=\"http://edelta/PersonList/v4\">\n" + "  <members xsi:type=\"person:Male\"\n"
+				+ "      name=\"John Doe\"/>\n" + "  <members xsi:type=\"person:Female\"\n"
+				+ "      name=\"Jane Doe\"/>\n" + "</person:List>";
+	}
+
+	@Test
+	public void testModelMigration() throws Exception {
+		// Create mock multipart files
+		MockMultipartFile file1 = new MockMultipartFile("modelFiles", "My.persons", MediaType.TEXT_XML_VALUE,
+				inputXml1.getBytes(StandardCharsets.UTF_8));
+
+		MockMultipartFile file2 = new MockMultipartFile("modelFiles", "My2.persons", MediaType.TEXT_XML_VALUE,
+				inputXml2.getBytes(StandardCharsets.UTF_8));
+
+		// Perform the multipart request and get the result
+		MvcResult result = mockMvc.perform(multipart("/api/v1/migrationservice/").file(file1).file(file2))
+				.andExpect(status().isOk()).andReturn();
+
+		// Get the response as byte array
+		byte[] responseBytes = result.getResponse().getContentAsByteArray();
+
+		// Verify the response
+		assertNotNull(responseBytes);
+
+		// Extract and verify the contents of the zip file
+		ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(responseBytes));
+		ZipEntry entry;
+
+		// Maps to store the extracted content
+		String extractedContent1 = null;
+		String extractedContent2 = null;
+
+		while ((entry = zipInputStream.getNextEntry()) != null) {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			byte[] buffer = new byte[1024];
+			int len;
+			while ((len = zipInputStream.read(buffer)) > 0) {
+				outputStream.write(buffer, 0, len);
+			}
+
+			String content = outputStream.toString(StandardCharsets.UTF_8.name());
+
+			if (entry.getName().equals("My.persons")) {
+				extractedContent1 = content;
+			} else if (entry.getName().equals("My2.persons")) {
+				extractedContent2 = content;
+			}
+
+			zipInputStream.closeEntry();
+		}
+		zipInputStream.close();
+
+		// Normalize whitespace for comparison
+		assertNotNull(extractedContent1, "My.persons not found in the ZIP file");
+		assertNotNull(extractedContent2, "My2.persons not found in the ZIP file");
+
+		// Compare the extracted content with expected output
+		assertEquals(normalizeXml(expectedOutputXml1), normalizeXml(extractedContent1));
+		assertEquals(normalizeXml(expectedOutputXml2), normalizeXml(extractedContent2));
+	}
+
+	/**
+	 * Helper method to normalize XML by removing whitespace between tags for easier
+	 * comparison
+	 */
+	private String normalizeXml(String xml) {
+		return xml.replaceAll(">\\s+<", "><").trim();
+	}
+}

--- a/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
+++ b/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
@@ -7,12 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 

--- a/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
+++ b/src/test/java/it/gssi/edelta/migrationservice/api/MigrationControllerTest.java
@@ -156,20 +156,21 @@ public class MigrationControllerTest {
 		}
 		zipInputStream.close();
 
-		// Normalize whitespace for comparison
+		// Verify the model files are present in the ZIP
 		assertNotNull(extractedContent1, "My.persons not found in the ZIP file");
 		assertNotNull(extractedContent2, "My2.persons not found in the ZIP file");
 
-		// Compare the extracted content with expected output
-		assertEquals(normalizeXml(expectedOutputXml1), normalizeXml(extractedContent1));
-		assertEquals(normalizeXml(expectedOutputXml2), normalizeXml(extractedContent2));
+		// Compare the extracted content with expected output using normalized line endings
+		assertEquals(normalizeLineEndings(expectedOutputXml1), normalizeLineEndings(extractedContent1));
+		assertEquals(normalizeLineEndings(expectedOutputXml2), normalizeLineEndings(extractedContent2));
 	}
 
 	/**
-	 * Helper method to normalize XML by removing whitespace between tags for easier
-	 * comparison
+	 * Helper method to normalize line endings to ensure consistent comparison
+	 * across different platforms.
 	 */
-	private String normalizeXml(String xml) {
-		return xml.replaceAll(">\\s+<", "><").trim();
+	private String normalizeLineEndings(String text) {
+		// Normalize line endings by removing carriage returns
+		return text.replace("\r", "");
 	}
 }

--- a/src/test/java/it/gssi/edelta/migrationservice/api/TestConfig.java
+++ b/src/test/java/it/gssi/edelta/migrationservice/api/TestConfig.java
@@ -1,0 +1,21 @@
+package it.gssi.edelta.migrationservice.api;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import it.gssi.edelta.migrationservice.configuration.MigrationConfigProperties;
+
+@TestConfiguration
+public class TestConfig {
+
+	/**
+	 * Create a test-specific MigrationConfigProperties bean This allows us to
+	 * override the model folder path in tests
+	 */
+	@Bean
+	@Primary
+	public MigrationConfigProperties testMigrationConfigProperties() {
+		return new MigrationConfigProperties();
+	}
+}

--- a/src/test/resources/config/application-test.yml
+++ b/src/test/resources/config/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+model:
+  folder: ${java.io.tmpdir}/edelta-test-models

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
This pull request introduces several updates to the migration service, including dependency updates, enhanced logging, exception handling refinement, and the addition of comprehensive integration tests. The changes improve maintainability, testing coverage, and functionality.

### Dependency and Configuration Updates:
* Updated the Maven `xsi:schemaLocation` URL to use `http` instead of `https` in `pom.xml`.
* Modified dependencies in `pom.xml` to use the `io.github.lorenzobettini.edelta.examples` group ID for the `personlist.migrator` artifact.
* Added a new Maven repository for Sonatype Snapshots in `pom.xml`.

### Logging and Exception Handling:
* Enhanced logging in `MigrationController` to log the URIs of migrated models.
* Simplified exception handling in `MigrationController` by removing redundant logging for `IOException`.

### Testing Enhancements:
* Added a new integration test class `MigrationControllerTest` to validate the migration service functionality, including XML input/output verification and ZIP file content checks.
* Introduced a `TestConfig` class to provide test-specific configurations, enabling overrides for the model folder path in tests.
* Added `application-test.yml` to configure test-specific properties, such as file size limits and a temporary model folder.
* Updated `application.yml` to activate the `test` profile by default during testing.