### PR TITLE
use the new central portal snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,15 +82,14 @@
 
 	<repositories>
 		<repository>
-			<id>sonatype-snapshots</id>
-			<name>Sonatype Snapshots</name>
-			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+			<name>Central Portal Snapshots</name>
+			<id>central-portal-snapshots</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
 			<snapshots>
 				<enabled>true</enabled>
-				<updatePolicy>daily</updatePolicy>
 			</snapshots>
 		</repository>
 	</repositories>


### PR DESCRIPTION
I now publish snapshots to the new Central repository, so the configuration must be updated accordingly

This pull request updates the Maven repository configuration in the `pom.xml` file to reflect a new snapshot repository URL and associated metadata.

Repository configuration changes:

* Updated the repository `id` from `sonatype-snapshots` to `central-portal-snapshots` and the `name` to `Central Portal Snapshots`.
* Changed the repository URL from `https://s01.oss.sonatype.org/content/repositories/snapshots` to `https://central.sonatype.com/repository/maven-snapshots/`.
* Removed the `<updatePolicy>` element under `<snapshots>`.